### PR TITLE
Bump libde265 to v1.0.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main]
   push:
     tags:
       - "*"
@@ -45,8 +47,7 @@ jobs:
           wget
 
       - name: Install ImageMagick format dependencies
-        run: >
-          apt-get -y install ${{ matrix.imagemagick-dependencies }}
+        run: apt-get -y install ${{ matrix.imagemagick-dependencies }}
 
       - name: Build libde265 ${{ matrix.libde265-version }} from source
         run: |
@@ -116,7 +117,10 @@ jobs:
           --without-pango
           --without-wmf &&
           make &&
-          checkinstall --pkgversion=$(echo "${{ matrix.imagemagick-version }}" | cut -d- -f1) --pkgrelease=$(echo "${{ matrix.imagemagick-version }}" | cut -d- -f2) --requires=$(echo "${{ matrix.imagemagick-dependencies }}" | tr -s '[:blank:]' ',') &&
+          checkinstall 
+          --pkgversion=$(echo "${{ matrix.imagemagick-version }}" | cut -d- -f1) 
+          --pkgrelease=$(echo "${{ matrix.imagemagick-version }}" | cut -d- -f2) 
+          --requires=$(echo "${{ matrix.imagemagick-dependencies }}" | tr -s '[:blank:]' ',') &&
           ldconfig &&
           mv imagemagick_*.deb ../binaries/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         ubuntu-version:
           - focal
           - jammy
-        libde265-version: ["1.0.8"]
+        libde265-version: ["1.0.9"]
         libheif-version: ["1.13.0"]
         imagemagick-version: ["7.1.0-51"]
         imagemagick-dependencies: ["libbz2-dev libfontconfig1-dev libfreetype-dev libgs-dev liblcms2-dev liblzma-dev libopenexr-dev libopenjp2-7-dev libjpeg-turbo8-dev libpng-dev liblqr-1-0-dev libglib2.0-dev libraw-dev libtiff-dev libwebp-dev libxml2-dev libx11-dev libx265-dev libaom-dev zlib1g libltdl7"]


### PR DESCRIPTION
This pull request was [created automatically](https://github.com/vintagesucks/imagemagick-deb/blob/main/.github/workflows/update-libde265.yml).