### PR TITLE
Bump libde265 to v1.0.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         ubuntu-version:
           - focal
           - jammy
-        libde265-version: ["1.0.8"]
+        libde265-version: ["1.0.9"]
         libheif-version: ["1.13.0"]
         imagemagick-version: ["7.1.0-51"]
         imagemagick-dependencies: ["libbz2-dev libfontconfig1-dev libfreetype-dev libgs-dev liblcms2-dev liblzma-dev libopenexr-dev libopenjp2-7-dev libjpeg-turbo8-dev libpng-dev liblqr-1-0-dev libglib2.0-dev libraw-dev libtiff-dev libwebp-dev libxml2-dev libx11-dev libx265-dev libaom-dev zlib1g libltdl7"]


### PR DESCRIPTION
This pull request was [created automatically](https://github.com/vintagesucks/imagemagick-deb/blob/main/.github/workflows/update-libde265.yml).