### PR TITLE
Bump libheif to v1.14.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       matrix:
         ubuntu-version:
-          - focal
           - jammy
         libde265-version: ["1.0.9"]
-        libheif-version: ["1.13.0"]
+        libheif-version: ["1.14.0"]
+        libheif-dependencies: ["libx265-dev libaom-dev"]
         imagemagick-version: ["7.1.0-52"]
-        imagemagick-dependencies: ["libbz2-dev libfontconfig1-dev libfreetype-dev libgs-dev liblcms2-dev liblzma-dev libopenexr-dev libopenjp2-7-dev libjpeg-turbo8-dev libpng-dev liblqr-1-0-dev libglib2.0-dev libraw-dev libtiff-dev libwebp-dev libxml2-dev libx11-dev libx265-dev libaom-dev zlib1g libltdl7"]
+        imagemagick-dependencies: ["libbz2-dev libfontconfig1-dev libfreetype-dev libgs-dev liblcms2-dev liblzma-dev libopenexr-dev libopenjp2-7-dev libjpeg-turbo8-dev libpng-dev liblqr-1-0-dev libglib2.0-dev libraw-dev libtiff-dev libwebp-dev libxml2-dev libx11-dev zlib1g libltdl7"]
 
     container:
       image: ubuntu:${{ matrix.ubuntu-version }}
@@ -46,9 +46,6 @@ jobs:
           software-properties-common
           wget
 
-      - name: Install ImageMagick format dependencies
-        run: apt-get -y install ${{ matrix.imagemagick-dependencies }}
-
       - name: Build libde265 ${{ matrix.libde265-version }} from source
         run: |
           git clone --depth 1 --branch v${{ matrix.libde265-version }} https://github.com/strukturag/libde265.git
@@ -59,15 +56,23 @@ jobs:
           checkinstall --pkgversion="${{ matrix.libde265-version }}"
           mv libde265_*.deb ../binaries/
 
+      - name: Install libheif dependencies
+        run: apt-get -y install ${{ matrix.libheif-dependencies }}
+
       - name: Build libheif ${{ matrix.libheif-version }} from source
-        run: |
-          git clone --depth 1 --branch v${{ matrix.libheif-version }} https://github.com/strukturag/libheif.git
-          cd libheif
-          ./autogen.sh
-          ./configure
-          make
-          checkinstall --pkgversion="${{ matrix.libheif-version }}"
+        run: >
+          git clone --depth 1 --branch v${{ matrix.libheif-version }} https://github.com/strukturag/libheif.git &&
+          cd libheif &&
+          ./autogen.sh &&
+          ./configure &&
+          make &&
+          checkinstall 
+          --pkgversion="${{ matrix.libheif-version }}" 
+          --requires=$(echo "${{ matrix.libheif-dependencies }}" | tr -s '[:blank:]' ',') &&
           mv libheif_*.deb ../binaries/
+
+      - name: Install ImageMagick format dependencies
+        run: apt-get -y install ${{ matrix.imagemagick-dependencies }}
 
       - name: Check ImageMagick dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ```sh
 apt-get update
 apt install ./jammy_libde265_*.deb
-apt install ./jammy_libheif_*.deb
+apt install -y ./jammy_libheif_*.deb
 apt install -y ./jammy_imagemagick_*.deb
 ldconfig
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ magick -list format
       ARW  DNG       r--   Sony Alpha Raw Image Format (0.20.2-Release)
    ASHLAR* ASHLAR    -w+   Image sequence laid out in continuous irregular courses
       AVI  VIDEO     r--   Microsoft Audio/Visual Interleaved
-     AVIF  HEIC      rw+   AV1 Image File Format (1.13.0)
+     AVIF  HEIC      rw+   AV1 Image File Format (1.14.0)
       AVS* AVS       rw+   AVS X image
     BAYER* BAYER     rw+   Raw mosaiced samples
    BAYERA* BAYER     rw+   Raw mosaiced and alpha samples
@@ -126,8 +126,8 @@ $ magick -list format
        GV  DOT       ---   Graphviz
      HALD* HALD      r--   Identity Hald color lookup table image
       HDR* HDR       rw+   Radiance RGBE image format
-     HEIC  HEIC      rw+   High Efficiency Image Format (1.13.0)
-     HEIF  HEIC      rw+   High Efficiency Image Format (1.13.0)
+     HEIC  HEIC      rw+   High Efficiency Image Format (1.14.0)
+     HEIF  HEIC      rw+   High Efficiency Image Format (1.14.0)
 HISTOGRAM* HISTOGRAM -w-   Histogram of the image
       HRZ* HRZ       rw-   Slow Scan TeleVision
       HTM* HTML      -w-   Hypertext Markup Language and a client-side image map


### PR DESCRIPTION
https://github.com/strukturag/libheif/releases/tag/v1.14.0