### PR TITLE
Bump libheif to v1.14.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         ubuntu-version:
           - jammy
         libde265-version: ["1.0.9"]
-        libheif-version: ["1.14.1"]
+        libheif-version: ["1.14.2"]
         libheif-dependencies: ["libx265-dev libaom-dev"]
         imagemagick-version: ["7.1.0-57"]
         imagemagick-epoch: ["8:"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ magick -list format
       ARW  DNG       r--   Sony Alpha Raw Image Format (0.20.2-Release)
    ASHLAR* ASHLAR    -w+   Image sequence laid out in continuous irregular courses
       AVI  VIDEO     r--   Microsoft Audio/Visual Interleaved
-     AVIF  HEIC      rw+   AV1 Image File Format (1.14.1)
+     AVIF  HEIC      rw+   AV1 Image File Format (1.14.2)
       AVS* AVS       rw+   AVS X image
     BAYER* BAYER     rw+   Raw mosaiced samples
    BAYERA* BAYER     rw+   Raw mosaiced and alpha samples
@@ -126,8 +126,8 @@ $ magick -list format
        GV  DOT       ---   Graphviz
      HALD* HALD      r--   Identity Hald color lookup table image
       HDR* HDR       rw+   Radiance RGBE image format
-     HEIC  HEIC      rw+   High Efficiency Image Format (1.14.1)
-     HEIF  HEIC      rw+   High Efficiency Image Format (1.14.1)
+     HEIC  HEIC      rw+   High Efficiency Image Format (1.14.2)
+     HEIF  HEIC      rw+   High Efficiency Image Format (1.14.2)
 HISTOGRAM* HISTOGRAM -w-   Histogram of the image
       HRZ* HRZ       rw-   Slow Scan TeleVision
       HTM* HTML      -w-   Hypertext Markup Language and a client-side image map


### PR DESCRIPTION
https://github.com/strukturag/libheif/releases/tag/v1.14.2