### PR TITLE
Bump libde265 to v1.0.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         ubuntu-version:
           - jammy
-        libde265-version: ["1.0.9"]
+        libde265-version: ["1.0.10"]
         libheif-version: ["1.14.2"]
         libheif-dependencies: ["libx265-dev libaom-dev"]
         imagemagick-version: ["7.1.0-58"]
@@ -142,7 +142,7 @@ jobs:
         run: cd binaries && for f in * ; do mv -- "$f" "${{ matrix.ubuntu-version }}_$f" ; done
 
       - name: List binaries
-        run: ls binaries
+        run: ls -lah binaries
 
       - name: Archive binary artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
https://github.com/strukturag/libde265/releases/tag/v1.0.10