### PR TITLE
Bump libheif to v1.18.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN pkg-config --exists --print-errors "libde265 = $LIBDE265_VERSION"
 WORKDIR /
 
 # Build libheif from source
-ENV LIBHEIF_VERSION="1.17.6"
+ENV LIBHEIF_VERSION="1.18.1"
 RUN git clone --depth 1 --branch v$LIBHEIF_VERSION https://github.com/strukturag/libheif.git
 WORKDIR libheif
 WORKDIR build

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ magick -list format
       ARW  DNG       r--   Sony Alpha Raw Format (0.21.2-Release)
    ASHLAR* ASHLAR    -w+   Image sequence laid out in continuous irregular courses
       AVI  VIDEO     r--   Microsoft Audio/Visual Interleaved
-     AVIF  HEIC      rw+   AV1 Image File Format (1.17.6)
+     AVIF  HEIC      rw+   AV1 Image File Format (1.18.1)
       AVS* AVS       rw+   AVS X image
     BAYER* BAYER     rw+   Raw mosaiced samples
    BAYERA* BAYER     rw+   Raw mosaiced and alpha samples
@@ -148,8 +148,8 @@ $ magick -list format
        GV  DOT       ---   Graphviz
      HALD* HALD      r--   Identity Hald color lookup table image
       HDR* HDR       rw+   Radiance RGBE image format
-     HEIC  HEIC      rw+   High Efficiency Image Format (1.17.6)
-     HEIF  HEIC      rw+   High Efficiency Image Format (1.17.6)
+     HEIC  HEIC      rw+   High Efficiency Image Format (1.18.1)
+     HEIF  HEIC      rw+   High Efficiency Image Format (1.18.1)
 HISTOGRAM* HISTOGRAM -w-   Histogram of the image
       HRZ* HRZ       rw-   Slow Scan TeleVision
       HTM* HTML      -w-   Hypertext Markup Language and a client-side image map


### PR DESCRIPTION
https://github.com/strukturag/libheif/releases/tag/v1.18.1

closes #151