### PR TITLE
Bump libheif to v1.19.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN pkg-config --exists --print-errors "libde265 = $LIBDE265_VERSION"
 WORKDIR /
 
 # Build libheif from source
-ENV LIBHEIF_VERSION="1.19.7"
+ENV LIBHEIF_VERSION="1.19.8"
 RUN git clone --depth 1 --branch v$LIBHEIF_VERSION https://github.com/strukturag/libheif.git
 WORKDIR libheif
 WORKDIR build


### PR DESCRIPTION
https://github.com/strukturag/libheif/releases/tag/v1.19.8