### PR TITLE
build provenance: migrate to actions/attest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         run: magick -list format
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         if: contains(github.ref, 'tags')
         with:
           subject-path: 'binaries/*'


### PR DESCRIPTION
see https://github.com/actions/attest-build-provenance/releases/tag/v4.1.0